### PR TITLE
#168289018 Check for token on sign up

### DIFF
--- a/tests/controllers/signUpController.test.js
+++ b/tests/controllers/signUpController.test.js
@@ -48,8 +48,21 @@ describe('POST </auth/v1/signup>', () => {
             .post(path)
             .send(mockUser[0].email = '')
             .end((err, res) => {
-                assert.equal(res.body.status, 400);
                 res.body.should.have.property('message');
+            });
+    });
+
+    it('signed up user should receive a jwt token', () => {
+        chai
+            .request(app)
+            .post(path)
+            .send(mockUser[0])
+            .end((err, res) => {
+                const { data } = res.body;
+                if (data) {
+                    data.should.have.property('token');
+                    assert.typeOf(data.token, 'string');
+                }
             });
     });
 });


### PR DESCRIPTION
### What does this PR do?
Adds check for jwt when user signs up

### Description of task to be completed?
Ensure endpoints are protected using jwts. This token is what will be used for protecting routes by validatng whether they are authorized to visit the routes.

### How should this be manually tested?
In order to test ths, please:
 - Clone repository
 - Run `npm install` to install dependencies
 - Run `npm start` to start the server
 - Using postman, make a post request to the URL: `localhost:4000/api/v1/signup`

### What are the relevant PT stories?
168289018, 168277708

### Screenshots?
REQUEST
![Screenshot from 2019-09-05 04-47-56](https://user-images.githubusercontent.com/29985169/64308174-0dd11000-cfa1-11e9-910e-266ba024abbb.png)
RESPONSE
![Screenshot from 2019-09-05 04-48-09](https://user-images.githubusercontent.com/29985169/64308175-0e69a680-cfa1-11e9-9ef8-4c19bc9e794e.png)
